### PR TITLE
Fix linker error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ALL=px
 
 CFLAGS=-g -O2 -Wall -Wno-switch -Wextra -Wwrite-strings
-LDFLAGS=-lproc2
+LDLIBS=-lproc2
 
 DESTDIR=
 PREFIX=/usr/local


### PR DESCRIPTION
Right now, build fails for me on Ubuntu 24.04 with the following error:

```none
cc -g -O2 -Wall -Wno-switch -Wextra -Wwrite-strings  -lproc2  px.c   -o px
/usr/bin/ld: /tmp/ccFLBgOs.o: in function `main':
/scratch/px/px.c:70:(.text.startup+0x54): undefined reference to `procps_stat_new'
/usr/bin/ld: /scratch/px/px.c:75:(.text.startup+0x6b): undefined reference to `procps_stat_get'
/usr/bin/ld: /scratch/px/px.c:76:(.text.startup+0x8c): undefined reference to `procps_stat_unref'
/usr/bin/ld: /scratch/px/px.c:107:(.text.startup+0xce): undefined reference to `procps_pids_new'
/usr/bin/ld: /scratch/px/px.c:126:(.text.startup+0x183): undefined reference to `procps_pids_reap'
collect2: error: ld returned 1 exit status
make: *** [<builtin>: px] Error 1
```

This PR fixes the build.
