### PR TITLE
Fix VSZ reporting and update usage/docs

### DIFF
--- a/README
+++ b/README
@@ -22,7 +22,7 @@ DESCRIPTION
 
 EXIT STATUS
      The px utility returns 0 when a process was found, 1 if no process was
-     found, and 2 when other errors occured.
+     found, and 2 when other errors occurred.
 
 SEE ALSO
      pgrep(1), ps(1)
@@ -37,5 +37,3 @@ LICENSE
      copyright and related or neighboring rights to this work.
 
      http://creativecommons.org/publicdomain/zero/1.0/
-
-Void Linux                      April 15, 2024                      Void Linux

--- a/px.1
+++ b/px.1
@@ -34,7 +34,7 @@ The
 .Nm
 utility returns 0 when a process was found,
 1 if no process was found,
-and 2 when other errors occured.
+and 2 when other errors occurred.
 .Sh SEE ALSO
 .Xr pgrep 1 ,
 .Xr ps 1

--- a/px.c
+++ b/px.c
@@ -106,7 +106,7 @@ main(int argc, char *argv[])
 		EU_VM_RSS,
 		EU_VM_SIZE,
 	};
-	if ((r = procps_pids_new(&pids_info, items, 12)) < 0) {
+	if ((r = procps_pids_new(&pids_info, items, 13)) < 0) {
 		fprintf(stderr, "failed to run procps_pids_new: %s\n",
 		    strerror(-r));
 		exit(2);
@@ -121,7 +121,7 @@ main(int argc, char *argv[])
 		case 'f': fflag = 1; break;
 		default:
 			fprintf(stderr,
-			    "Usage: %s [-f] [PATTERN...]\n", argv[0]);
+			    "Usage: %s [-f] [-t] [PATTERN...]\n", argv[0]);
 			exit(2);
 		}
 


### PR DESCRIPTION
Small fix in `px.c`: pass the correct item count to `procps_pids_new` (`13` instead of `12`) so `VSZ` is reported correctly.

Also:
  - include `-t` in usage string
  - fix `occured` -> `occurred` in docs
  - drop trailing `Void Linux ...` line from README

Tested with `make` and `./px tmux` (VSZ now shows expected non-zero values).

```
$  ./px tmux
  PID USER     %CPU  VSZ  RSS START ELAPSED CPUTIME COMMAND
 9446 r1w1s1    0.0 5.9M 4.0M 08:43   9h29m    0:00 tmux
 9448 r1w1s1    0.0 9.3M 6.4M 08:43   9h29m    0:10 tmux

```